### PR TITLE
Change signal provided by timeout command from INT to TERM to stop the server from running forever

### DIFF
--- a/src/factorio-save-upgrader
+++ b/src/factorio-save-upgrader
@@ -114,7 +114,7 @@ function runFactorioVersion() {
 
   # NOTE: running the server with a timeout, so it shuts down even if the map loaded correctly.
   # NOTE: you can connect to the running server if you direct connect to localhost.
-  timeout --signal 'INT' "$FACTORIO_TIMEOUT" \
+  timeout "$FACTORIO_TIMEOUT" \
     docker run \
       --init \
       --rm \


### PR DESCRIPTION
Hello,

First of all, really nice tool. I was able to convert my old forgotten 0.16 save.

However I had to modify your script to make it work. Currently you send the INT signal with the `timeout` command to docker to stop the factorio server container. But that doesn't appear to work on my end as the server never stops.

This pull request removes the `--signal 'INT'` option from the `timeout` call so the default signal (`TERM`) is used instead.

This allows the factorio server to terminate once the 60s timeout has elapsed.

I'm not sure if this fixes the underlying issue. After all, there must be a reason the INT signal is sent specifically.